### PR TITLE
fix: darken dark mode theme with black/grey color scheme

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -9,21 +9,21 @@
 :root {
     --primary-color: #2563eb;
     --primary-hover: #1d4ed8;
-    --background: #0f172a;
-    --surface: #1e293b;
-    --surface-hover: #334155;
-    --text-primary: #f1f5f9;
-    --text-secondary: #94a3b8;
-    --border-color: #334155;
+    --background: #000000;
+    --surface: #0a0a0a;
+    --surface-hover: #1a1a1a;
+    --text-primary: #e5e5e5;
+    --text-secondary: #8a8a8a;
+    --border-color: #1a1a1a;
     --user-message: #2563eb;
-    --assistant-message: #374151;
-    --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+    --assistant-message: #141414;
+    --shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.5);
     --radius: 12px;
     --focus-ring: rgba(37, 99, 235, 0.2);
-    --welcome-bg: #1e3a5f;
+    --welcome-bg: #0f0f0f;
     --welcome-border: #2563eb;
-    --code-bg: rgba(0, 0, 0, 0.2);
-    --source-item-bg: rgba(255, 255, 255, 0.03);
+    --code-bg: rgba(0, 0, 0, 0.4);
+    --source-item-bg: rgba(255, 255, 255, 0.02);
     --source-border: rgba(96, 165, 250, 0.3);
 }
 


### PR DESCRIPTION
Updated dark mode colors to be significantly darker:
- Changed background from blue-grey (#0f172a) to pure black (#000000)
- Updated surfaces to very dark greys (#0a0a0a, #1a1a1a)
- Changed text colors to neutral greys for better contrast
- Removed blue tint from all dark mode colors

Fixes #2